### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/Agent-protocol/simplewrapper.ipynb
+++ b/Agent-protocol/simplewrapper.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install pyautogen~=0.1.0 docker\n",
+    "%pip install ag2~=0.1.0 docker\n",
     "%pip install agent-protocol\n",
     "\n"
    ]

--- a/Fine-Tuning/oai_completion.ipynb
+++ b/Fine-Tuning/oai_completion.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "AutoGen requires `Python>=3.8`. To run this notebook example, please install with the [blendsearch] option:\n",
     "```bash\n",
-    "pip install pyautogen[blendsearch]\n",
+    "pip install ag2[blendsearch]\n",
     "```"
    ]
   },
@@ -49,7 +49,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install \"pyautogen[blendsearch]~=0.1.0\" datasets"
+    "# %pip install \"ag2[blendsearch]~=0.1.0\" datasets"
    ]
   },
   {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
